### PR TITLE
update ghactions4r location

### DIFF
--- a/.github/workflows/call-calc-coverage.yml
+++ b/.github/workflows/call-calc-coverage.yml
@@ -5,6 +5,6 @@ name: call-calc_coverage
 on: [push, pull_request]
 jobs:
   call-workflow:
-    uses: nmfs-fish-tools/ghactions4r/.github/workflows/calc-coverage.yml@main
+    uses: nmfs-ost/ghactions4r/.github/workflows/calc-coverage.yml@main
     with:
       use-public-rspm: false

--- a/.github/workflows/call-doc-and-style-r.yml
+++ b/.github/workflows/call-doc-and-style-r.yml
@@ -6,5 +6,5 @@ on:
     branches: [main]
 jobs:
   call-workflow:
-    uses: nmfs-fish-tools/ghactions4r/.github/workflows/doc-and-style-r.yml@main
+    uses: nmfs-ost/ghactions4r/.github/workflows/doc-and-style-r.yml@main
   

--- a/.github/workflows/call-r-cmd-check.yml
+++ b/.github/workflows/call-r-cmd-check.yml
@@ -10,6 +10,6 @@ on:
     #- cron: '0 0 * * 0'
 jobs:
   call-workflow:
-    uses: nmfs-fish-tools/ghactions4r/.github/workflows/r-cmd-check.yml@main
+    uses: nmfs-ost/ghactions4r/.github/workflows/r-cmd-check.yml@main
     with:
       depends_on_tmb: true

--- a/.github/workflows/call-spell-check.yml
+++ b/.github/workflows/call-spell-check.yml
@@ -12,4 +12,4 @@ on:
   workflow_dispatch:
 jobs:
   call-workflow:
-    uses: nmfs-fish-tools/ghactions4r/.github/workflows/spell-check.yml@main
+    uses: nmfs-ost/ghactions4r/.github/workflows/spell-check.yml@main

--- a/.github/workflows/call-update-pkgdown.yml
+++ b/.github/workflows/call-update-pkgdown.yml
@@ -9,4 +9,4 @@ on:
     tags: ['*']
 jobs:
   call-workflow:
-    uses: nmfs-fish-tools/ghactions4r/.github/workflows/update-pkgdown.yml@main
+    uses: nmfs-ost/ghactions4r/.github/workflows/update-pkgdown.yml@main


### PR DESCRIPTION
Hello, this repository depends on [ghactions4r](https://github.com/nmfs-fish-tools/ghactions4r). The ghactions4r repository will be moving from https://github.com/nmfs-fish-tools/ghactions4r to https://github.com/nmfs-ost/ghactions4r on **May 16, 2025 between 9 am and 12 pm pacific**. When the move happens, all GitHub actions workflows that reference a ghactions4r workflow will break.



**To keep actions from breaking, please take a look at your github action YAML files (located under .github/workflows in your repository) and change any references of nmfs-fish-tools/ghactions4r (the old organization) to nmfs-ost/ghactions4r (the new organization) between now and May 16**. This has been done for you in this pull request, so it can simply be merged in.


If you would like to make the changes yourself, the [global replace tool in Rstudio](https://posit.co/wp-content/themes/Posit/public/markdown-blogs/rstudio-1-3-the-little-things/index.html#global-replace) or the [search across files functionality in vs code](https://code.visualstudio.com/docs/editing/codebasics#_search-across-files) can help you quickly find all instances of nmfs-fish-tools/ghactions4r and replace them with nmfs-ost/ghactions4r.

For example, someone using the call-spell-check.yml file would change the line

```yml
    uses: nmfs-fish-tools/ghactions4r/.github/workflows/spell-check.yml@main
```

to

```yml
    uses: nmfs-ost/ghactions4r/.github/workflows/spell-check.yml@main
```

Please reach out if you have any questions.
